### PR TITLE
Calculate commits between base and head using compare API

### DIFF
--- a/src/compare.ts
+++ b/src/compare.ts
@@ -1,0 +1,50 @@
+import * as core from '@actions/core'
+import { GitHub } from '@actions/github/lib/utils'
+
+type Octokit = InstanceType<typeof GitHub>
+
+type Inputs = {
+  owner: string
+  repo: string
+  base: string
+  head: string
+}
+
+type Outputs = {
+  commitIds: Set<string>
+  earliestCommitId: string
+  earliestCommitDate: Date
+}
+
+export const compareCommits = async (octokit: Octokit, inputs: Inputs): Promise<Outputs> => {
+  const { data: rateLimitBefore } = await octokit.rest.rateLimit.get()
+  core.info(`Remaining core rate limit: ${rateLimitBefore.resources.core.remaining}`)
+
+  const compare = await octokit.paginate(octokit.rest.repos.compareCommitsWithBasehead, {
+    owner: inputs.owner,
+    repo: inputs.repo,
+    basehead: `${inputs.base}...${inputs.head}`,
+    per_page: 100,
+  })
+
+  const { data: rateLimitAfter } = await octokit.rest.rateLimit.get()
+  core.info(
+    `Remaining core rate limit: ${rateLimitAfter.resources.core.remaining} (used ${
+      rateLimitBefore.resources.core.remaining - rateLimitAfter.resources.core.remaining
+    })`
+  )
+
+  const commitIds = new Set(compare.commits.map((commit) => commit.sha))
+  let earliestCommitDate = new Date()
+  let earliestCommitId = ''
+  for (const commit of compare.commits) {
+    if (commit.commit.committer?.date) {
+      const d = new Date(commit.commit.committer.date)
+      if (d < earliestCommitDate) {
+        earliestCommitDate = d
+        earliestCommitId = commit.sha
+      }
+    }
+  }
+  return { commitIds, earliestCommitId, earliestCommitDate }
+}

--- a/src/compare.ts
+++ b/src/compare.ts
@@ -34,6 +34,10 @@ export const compareCommits = async (octokit: Octokit, inputs: Inputs): Promise<
     })`
   )
 
+  core.startGroup(`compareCommitsWithBasehead`)
+  core.info(JSON.stringify(compare, undefined, 2))
+  core.endGroup()
+
   const commitIds = new Set(compare.commits.map((commit) => commit.sha))
   let earliestCommitDate = new Date()
   let earliestCommitId = ''


### PR DESCRIPTION
## Problem to solve
Currently, this action calculates the earliest commit date from `merge_base_commit` of Compare API. If base commit is newer than any commit of whole diff between base and head, it is wrong.

For example of the below graph,

```mermaid
graph LR
  A --> B --> C --> D --> E --> head
  B --> X --> base
  X --> E
```

`merge_base_commit` is X, but the earliest commit date should be C.

## How to solve
We need to fetch whole commits by Compare API.

## Caveat
Compare API consumes a lot of rate limit if there are many commits between base and head.
