### PR TITLE
Do not sleep on 502 error

### DIFF
--- a/src/queries/getCommitHistory.ts
+++ b/src/queries/getCommitHistory.ts
@@ -65,8 +65,6 @@ const withRetry = (fn: QueryFunction) => async (v: GetCommitHistoryQueryVariable
       historySize: Math.floor(current.historySize * 0.8),
     }),
     remainingCount: 10,
-    afterMs: 3000,
-    maxJitterMs: 15000,
   })
 
 export const paginate = async (


### PR DESCRIPTION
This changes the retry conditions as follows:

- 403: Wait for up to twice of `retry-after` header
- 502: No wait
- Others: Wait for up to 10s