### PR TITLE
Add max-fetch-commits option

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,7 +182,8 @@ jobs:
 
 You need to set either `base` and `head`, or `pull-request`.
 
-For a large monorepo, you can set `max-fetch-commits` to avoid the rate limit or job timeout.
+If there is a very old commit in the repository, this action may fetch a lot of commits.
+You can set `max-fetch-commits` to avoid the job timeout or GitHub API rate-limit.
 
 ### Outputs
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 This is an action to generate a list of pull requests associated to a pull request.
 
-
 ## Purpose
 
 ### Problem to solve
@@ -82,11 +81,11 @@ You can group associated pull requests by paths.
 This feature is useful for monorepo.
 
 ```yaml
-      - uses: int128/list-associated-pull-requests-action@v1
-        with:
-          group-by-paths: |
-            backend
-            frontend
+- uses: int128/list-associated-pull-requests-action@v1
+  with:
+    group-by-paths: |
+      backend
+      frontend
 ```
 
 Here is an example.
@@ -98,15 +97,15 @@ This action ignores a line which starts with `#`.
 For example,
 
 ```yaml
-      - uses: int128/list-associated-pull-requests-action@v1
-        with:
-          group-by-paths: |
-            # microservices
-            payment-frontend
-            payment-backend
-            # monolith
-            frontend
-            api
+- uses: int128/list-associated-pull-requests-action@v1
+  with:
+    group-by-paths: |
+      # microservices
+      payment-frontend
+      payment-backend
+      # monolith
+      frontend
+      api
 ```
 
 ### How it groups
@@ -128,9 +127,12 @@ this action returns the following markdown:
 
 ```markdown
 ### api
+
 - #1
 - #2
+
 ### backend
+
 - #1
 - #3
 ```
@@ -139,7 +141,6 @@ this action returns the following markdown:
 
 If a pull request does not belong to any group, it is grouped as "Others".
 You can hide the Others group by `show-others-group`.
-
 
 ## Compare base and head
 
@@ -164,28 +165,29 @@ jobs:
             ${{ steps.associated-pull-requests.outputs.body }}
 ```
 
-
 ## Specification
 
 ### Inputs
 
-| Name | Default | Description
-|------|----------|------------
-| `token` | `github.token` | GitHub token
-| `pull-request` | <sup>*1</sup> | Pull request to parse
-| `group-by-paths` | (optional) | Group pull requests by paths (Multiline)
-| `show-others-group` | `true` | Show others group
-| `base` | <sup>*1</sup> | Base branch
-| `head` | <sup>*1</sup> | Head branch
-| `path` | `.` | Path to get the commit history of subtree
+| Name                | Default        | Description                               |
+| ------------------- | -------------- | ----------------------------------------- |
+| `token`             | `github.token` | GitHub token                              |
+| `pull-request`      | <sup>\*1</sup> | Pull request to parse                     |
+| `group-by-paths`    | (optional)     | Group pull requests by paths (Multiline)  |
+| `show-others-group` | `true`         | Show others group                         |
+| `base`              | <sup>\*1</sup> | Base branch                               |
+| `head`              | <sup>\*1</sup> | Head branch                               |
+| `path`              | `.`            | Path to get the commit history of subtree |
+| `max-fetch-commits` | (unlimited)    | Maximum number of commits to fetch        |
 
 You need to set either `base` and `head`, or `pull-request`.
 
+For a large monorepo, you can set `max-fetch-commits` to avoid the rate limit or job timeout.
 
 ### Outputs
 
-| Name | Description
-|------|------------
-| `body` | List of associated pull requests (Markdown)
-| `body-groups` | Grouped lists of associated pull requests (Markdown)
-| `body-others` | Others list of associated pull requests (Markdown)
+| Name          | Description                                          |
+| ------------- | ---------------------------------------------------- |
+| `body`        | List of associated pull requests (Markdown)          |
+| `body-groups` | Grouped lists of associated pull requests (Markdown) |
+| `body-others` | Others list of associated pull requests (Markdown)   |

--- a/action.yaml
+++ b/action.yaml
@@ -22,6 +22,9 @@ inputs:
     description: Show others group
     required: true
     default: 'true'
+  max-fetch-commits:
+    description: Maximum number of commits to fetch. Default is unlimited
+    required: false
 
 outputs:
   body:

--- a/src/history.ts
+++ b/src/history.ts
@@ -23,6 +23,7 @@ type GetCommitHistoryByPathVariables = {
   sinceCommitDate: Date
   sinceCommitId: string
   filterCommitIds: Set<string>
+  maxFetchCommits: number | undefined
 }
 
 export const getCommitHistoryByPath = async (
@@ -31,14 +32,20 @@ export const getCommitHistoryByPath = async (
 ): Promise<CommitHistoryByPath> => {
   const results = await Promise.all(
     variables.groupByPaths.map(async (path) => {
-      const query = await getCommitHistory.execute(octokit, {
-        owner: variables.owner,
-        name: variables.name,
-        expression: variables.expression,
-        since: variables.sinceCommitDate,
-        path,
-        historySize: 100,
-      })
+      const query = await getCommitHistory.execute(
+        octokit,
+        {
+          owner: variables.owner,
+          name: variables.name,
+          expression: variables.expression,
+          since: variables.sinceCommitDate,
+          path,
+          historySize: 100,
+        },
+        {
+          maxFetchCommits: variables.maxFetchCommits,
+        },
+      )
       return { path, query }
     }),
   )

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ const main = async (): Promise<void> => {
     head: core.getInput('head') || undefined,
     groupByPaths: core.getMultilineInput('group-by-paths'),
     showOthersGroup: core.getBooleanInput('show-others-group', { required: true }),
+    maxFetchCommits: Number.parseInt(core.getInput('max-fetch-commits')) || undefined,
   })
 
   core.setOutput('body', outputs.body)

--- a/src/run.ts
+++ b/src/run.ts
@@ -14,6 +14,7 @@ type Inputs = {
   head?: string
   groupByPaths: string[]
   showOthersGroup: boolean
+  maxFetchCommits: number | undefined
 }
 
 type Outputs = {
@@ -61,6 +62,7 @@ export const run = async (inputs: Inputs): Promise<Outputs> => {
       sinceCommitDate: compare.earliestCommitDate,
       sinceCommitId: compare.earliestCommitId,
       filterCommitIds: compare.commitIds,
+      maxFetchCommits: inputs.maxFetchCommits,
     })
     const bodyGroups = formatCommitHistory(commitHistoryGroupsAndOthers.groups)
     const bodyOthers = formatCommitHistory(new Map([['Others', commitHistoryGroupsAndOthers.others]]))
@@ -79,6 +81,7 @@ export const run = async (inputs: Inputs): Promise<Outputs> => {
     sinceCommitDate: compare.earliestCommitDate,
     sinceCommitId: compare.earliestCommitId,
     filterCommitIds: compare.commitIds,
+    maxFetchCommits: inputs.maxFetchCommits,
   })
   const body = formatCommitHistory(commitHistoryByPath)
   return { body, bodyGroups: body, bodyOthers: '' }

--- a/tests/github-integration.test.ts
+++ b/tests/github-integration.test.ts
@@ -20,6 +20,7 @@ describeOnlyIfToken('GitHub integration test', () => {
       pullRequest: 491,
       groupByPaths: ['src', 'tests', '.github'],
       showOthersGroup: true,
+      maxFetchCommits: undefined,
     })
     expect(outputs).toMatchSnapshot()
   }, 30000)

--- a/tests/queries/getCommitHistory.test.ts
+++ b/tests/queries/getCommitHistory.test.ts
@@ -27,7 +27,7 @@ describe('paginate', () => {
         },
       },
     })
-    const query = await paginate(mockFn, variables)
+    const query = await paginate(mockFn, variables, { maxFetchCommits: undefined })
     expect(mockFn).toHaveBeenCalledTimes(1)
     expect(query).toStrictEqual({
       repository: {
@@ -61,7 +61,7 @@ describe('paginate', () => {
         },
       },
     })
-    const query = await paginate(mockFn, variables)
+    const query = await paginate(mockFn, variables, { maxFetchCommits: undefined })
     expect(mockFn).toHaveBeenCalledTimes(1)
     expect(query).toStrictEqual({
       repository: {
@@ -125,7 +125,7 @@ describe('paginate', () => {
         },
       },
     })
-    const query = await paginate(mockFn, variables)
+    const query = await paginate(mockFn, variables, { maxFetchCommits: undefined })
     expect(mockFn).toHaveBeenCalledTimes(3)
     expect(query).toStrictEqual({
       repository: {


### PR DESCRIPTION
If there is a very old commit, this action may fetch a lot of commits. It would be nice to set a limit to fetch commits to avoid timeout or rate-limit.
