### PR TITLE
Support `max-fetch-days` for rate-limit and timeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,11 +179,12 @@ jobs:
 | `head`              | <sup>\*1</sup> | Head branch                               |
 | `path`              | `.`            | Path to get the commit history of subtree |
 | `max-fetch-commits` | (unlimited)    | Maximum number of commits to fetch        |
+| `max-fetch-days`    | (unlimited)    | Maximum number of days to fetch history   |
 
 You need to set either `base` and `head`, or `pull-request`.
 
 If there is a very old commit in the repository, this action may fetch a lot of commits.
-You can set `max-fetch-commits` to avoid the job timeout or GitHub API rate-limit.
+You can set `max-fetch-commits` or `max-fetch-days` to avoid the job timeout or GitHub API rate-limit.
 
 ### Outputs
 

--- a/action.yaml
+++ b/action.yaml
@@ -25,6 +25,9 @@ inputs:
   max-fetch-commits:
     description: Maximum number of commits to fetch. Default is unlimited
     required: false
+  max-fetch-days:
+    description: Maximum number of days to fetch history. Default is unlimited
+    required: false
 
 outputs:
   body:

--- a/src/main.ts
+++ b/src/main.ts
@@ -11,6 +11,7 @@ const main = async (): Promise<void> => {
       groupByPaths: core.getMultilineInput('group-by-paths'),
       showOthersGroup: core.getBooleanInput('show-others-group', { required: true }),
       maxFetchCommits: Number.parseInt(core.getInput('max-fetch-commits')) || undefined,
+      maxFetchDays: Number.parseInt(core.getInput('max-fetch-days')) || undefined,
     },
     getOctokit(),
     getContext(),

--- a/tests/github-integration.test.ts
+++ b/tests/github-integration.test.ts
@@ -17,6 +17,7 @@ describe.runIf(process.env.INTEGRATION_TEST_GITHUB_TOKEN)('GitHub integration te
         groupByPaths: ['src', 'tests', '.github'],
         showOthersGroup: true,
         maxFetchCommits: undefined,
+        maxFetchDays: undefined,
       },
       new Octokit({ auth: process.env.INTEGRATION_TEST_GITHUB_TOKEN, authStrategy: null }),
       {

--- a/tests/run.test.ts
+++ b/tests/run.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest'
+import { determineSinceCommitDate } from '../src/run.js'
+
+describe('determineSinceCommitDate', () => {
+  it('returns the earliestCommitDate if maxFetchDays is not set', () => {
+    const earliestCommitDate = new Date('2022-01-01T00:00:00Z')
+    const result = determineSinceCommitDate(earliestCommitDate, undefined)
+    expect(result).toEqual(earliestCommitDate)
+  })
+
+  it('returns the date limited by maxFetchDays if it is set', () => {
+    const earliestCommitDate = new Date('2022-01-01T00:00:00Z')
+    const now = new Date('2022-01-10T00:00:00Z')
+    const result = determineSinceCommitDate(earliestCommitDate, 5, now)
+    expect(result).toEqual(new Date('2022-01-05T00:00:00Z'))
+  })
+
+  it('returns the earliestCommitDate if it is more recent than the date limited by maxFetchDays', () => {
+    const earliestCommitDate = new Date('2022-01-07T00:00:00Z')
+    const now = new Date('2022-01-10T00:00:00Z')
+    const result = determineSinceCommitDate(earliestCommitDate, 5, now)
+    expect(result).toEqual(earliestCommitDate)
+  })
+})


### PR DESCRIPTION
## Problem to solve
For a large monorepo, `getCommitHistory` query may return 403 or 502 error. This provides a way to limit the `sinceCommitDate` of the query.
